### PR TITLE
Fix trailing slash in crds_gateway_endpoint method

### DIFF
--- a/lib/jekyll-crds/env.rb
+++ b/lib/jekyll-crds/env.rb
@@ -44,7 +44,7 @@ module Jekyll
         end
 
         def configure_gateway_endpoint
-          ENV['CRDS_GATEWAY_ENDPOINT'] || "https://gateway#{env_prefix unless @site.config['jekyll_env'] == 'production' }.crossroads.net/gateway/"
+          ENV['CRDS_GATEWAY_ENDPOINT'] ? "#{ENV['CRDS_GATEWAY_ENDPOINT']}/" : "https://gateway#{env_prefix unless @site.config['jekyll_env'] == 'production' }.crossroads.net/gateway/"
         end
     end
   end

--- a/lib/jekyll-crds/env.rb
+++ b/lib/jekyll-crds/env.rb
@@ -44,7 +44,7 @@ module Jekyll
         end
 
         def configure_gateway_endpoint
-          ENV['CRDS_GATEWAY_ENDPOINT'] ? "#{ENV['CRDS_GATEWAY_ENDPOINT']}/" : "https://gateway#{env_prefix unless @site.config['jekyll_env'] == 'production' }.crossroads.net/gateway/"
+          File.join(ENV['CRDS_GATEWAY_ENDPOINT'] || "https://gateway#{env_prefix unless @site.config['jekyll_env'] == 'production' }.crossroads.net/gateway/", "")
         end
     end
   end

--- a/spec/unit/env_generator_spec.rb
+++ b/spec/unit/env_generator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Jekyll::Crds::EnvGenerator do
     @site.config['jekyll_env'] = 'production'
     expect(@gen.send(:configure_gateway_endpoint)).to eq('https://gateway.crossroads.net/gateway/')
     ENV['CRDS_GATEWAY_ENDPOINT'] = 'https://gateway.crossroads.net/gateway'
-    expect(@gen.send(:configure_gateway_endpoint)).to eq('https://gateway.crossroads.net/gateway')
+    expect(@gen.send(:configure_gateway_endpoint)).to eq('https://gateway.crossroads.net/gateway/')
   end
 
   it 'should configure the shared header endpoints' do


### PR DESCRIPTION
Updated configure_gateway_endpoint method to use a ternary to decide how to populate the environment variable