### PR TITLE
DE6870: Google API Key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-crds (1.3.3)
+    jekyll-crds (1.3.4)
       activesupport
       httparty
       jekyll

--- a/lib/jekyll-crds/env.rb
+++ b/lib/jekyll-crds/env.rb
@@ -21,6 +21,7 @@ module Jekyll
         @site.config['url'] = ENV['SITE_URL'] if ENV['SITE_URL']
         configure_shared_header
         configure_stream_schedule
+        configure_envs
       end
 
 
@@ -43,6 +44,10 @@ module Jekyll
           @site.config['streamspotKey'] = ENV['STREAMSPOT_API_KEY']
           @site.config['streamspotId'] = ENV['STREAMSPOT_ID']
           @site.config['streamspotPlayerId'] = ENV['STREAMSPOT_PLAYER_ID']
+        end
+
+        def configure_envs
+          @site.config['google_api_key'] = ENV['GOOGLE_API_KEY']
         end
 
         def configure_gateway_endpoint

--- a/lib/jekyll-crds/version.rb
+++ b/lib/jekyll-crds/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Crds
-    VERSION = "1.3.3"
+    VERSION = "1.3.4"
   end
 end

--- a/spec/unit/env_generator_spec.rb
+++ b/spec/unit/env_generator_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Jekyll::Crds::EnvGenerator do
     ENV['IMGIX_SRC'] = 'contentful_url'
     ENV['IMGIX_DOMAIN'] = 'imgix_url'
     ENV["STREAM_SCHEDULE_ENDPOINT"] = "https://aws-lamba-function/int/stream-schedule"
+    ENV["GOOGLE_API_KEY"] = "1234657849"
     
     @gen = Jekyll::Crds::Env.new(@site)
   end
@@ -61,6 +62,10 @@ RSpec.describe Jekyll::Crds::EnvGenerator do
   it 'should set the correct stream schedule endpoint ' do 
     @gen.send(:configure_stream_schedule)
     expect(@site.config['stream_schedule_endpoint']).to eq('https://aws-lamba-function/int/stream-schedule')
+  end
+
+  it 'should set the Google Api Key' do
+    expect(@site.config['google_api_key']).to eq('1234657849')
   end
   
 end


### PR DESCRIPTION
We are having some issues with setting keys in crds-net (specifically for rollcall). This is our standard procedure for setting envs across Jekyll projects.