### PR TITLE
Fix meta_title method to display site title

### DIFF
--- a/lib/jekyll-crds/filters/meta_filters.rb
+++ b/lib/jekyll-crds/filters/meta_filters.rb
@@ -5,7 +5,7 @@ module Jekyll
 
     def meta_title(page)
 
-      return page['meta']['title'] if page.to_h.dig('meta', 'title').present?
+      return "#{escape(page['meta']['title'])} | #{escape(site.config['title'])}" if page.to_h.dig('meta', 'title').present?
 
       unless (system_page_title = match_system_page(get_url(page), 'title')).nil?
         return system_page_title

--- a/lib/jekyll-crds/version.rb
+++ b/lib/jekyll-crds/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Crds
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
   end
 end


### PR DESCRIPTION
Previously if a site page had provided meta data for a title, only the
title of the page would be used without appending the site title. These
changes ensure that if a site page has meta data for the title, the site
title gets appended to the page title.